### PR TITLE
Upgrade to github.com/oschwald/maxminddb-golang/v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: ["1.23"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     name: "Build ${{ matrix.go-version }} test on ${{ matrix.platform }}"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Required:
 Copyright and License
 =====================
 
-This software is Copyright (c) 2015-2024 by MaxMind, Inc.
+This software is Copyright (c) 2015-2025 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/maxmind/mmdbverify
 
-go 1.21
-
-toolchain go1.22.3
+go 1.23
 
 require github.com/oschwald/maxminddb-golang v1.13.1
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/maxmind/mmdbverify
 
 go 1.23
 
-require github.com/oschwald/maxminddb-golang v1.13.1
+require github.com/oschwald/maxminddb-golang/v2 v2.0.0-beta.2
 
-require golang.org/x/sys v0.21.0 // indirect
+require golang.org/x/sys v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,12 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/oschwald/maxminddb-golang v1.13.1 h1:G3wwjdN9JmIK2o/ermkHM+98oX5fS+k5MbwsmL4MRQE=
-github.com/oschwald/maxminddb-golang v1.13.1/go.mod h1:K4pgV9N/GcK694KSTmVSDTODk4IsCNThNdTmnaBZ/F8=
+github.com/oschwald/maxminddb-golang/v2 v2.0.0-beta.2 h1:jG+FaCBv3h6GD5F+oenTfe3+0NmX8sCKjni5k3A5Dek=
+github.com/oschwald/maxminddb-golang/v2 v2.0.0-beta.2/go.mod h1:rHaQJ5SjfCdL4sqCKa3FhklRcaXga2/qyvmQuA+ZJ6M=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/oschwald/maxminddb-golang"
+	"github.com/oschwald/maxminddb-golang/v2"
 )
 
 func main() {


### PR DESCRIPTION
- **Update copyright year**
- **Drop 1.21 and 1.22 support**
- **Update to github.com/oschwald/maxminddb-golang/v2**
